### PR TITLE
fix: use -isystem instead of -I

### DIFF
--- a/toolchain/config.bzl.tpl
+++ b/toolchain/config.bzl.tpl
@@ -289,10 +289,9 @@ def _impl(ctx):
                 ],
                 flag_groups = [
                     flag_group(
-                        flags = [
-                            "-I{}".format(d)
-                            for d in hermetic_include_directories
-                        ],
+                        flags = [item for sublist in [
+                            ["-isystem", d] for d in hermetic_include_directories
+                        ] for item in sublist],
                     ),
                 ],
             ),


### PR DESCRIPTION
This is particularly important for static analysis tools that will treat `-isystem` differently than `-I` values.