### PR TITLE
feat: expose all binaries

### DIFF
--- a/toolchain/toolchain.BUILD.bazel.tpl
+++ b/toolchain/toolchain.BUILD.bazel.tpl
@@ -46,6 +46,9 @@ filegroup(
     ],
 )
 
+# Export all binary files:
+exports_files(glob(["bin/**"]))
+
 # GCC
 
 filegroup(


### PR DESCRIPTION
This allows individual binaries to be called with e.g. `bazel run @gcc_toolchain//:bin/m4`.