### PR TITLE
fix: change defaults for hardcode_sysroot_{ld_linux,rpath}

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,8 @@ gcc_register_toolchain(
     sha256 = "6fe812add925493ea0841365f1fb7ca17fd9224bab61a731063f7f12f3a621b0",
     strip_prefix = "x86-64--glibc--stable-2021.11-5",
     target_arch = "x86_64",
+    hardcode_sysroot_ld_linux = True,
+    hardcode_sysroot_rpath = True,
 )
 
 gcc_register_toolchain(
@@ -25,8 +27,6 @@ gcc_register_toolchain(
     sha256 = "dec070196608124fa14c3f192364c5b5b057d7f34651ad58ebb8fc87959c97f7",
     strip_prefix = "aarch64--glibc--stable-2021.11-1",
     target_arch = "aarch64",
-    hardcode_sysroot_ld_linux = False,
-    hardcode_sysroot_rpath = False,
 )
 
 gcc_register_toolchain(
@@ -37,6 +37,4 @@ gcc_register_toolchain(
     target_arch = "armv7",
     binary_prefix = "arm",
     platform_directory = "arm-buildroot-linux-gnueabihf",
-    hardcode_sysroot_ld_linux = False,
-    hardcode_sysroot_rpath = False,
 )

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -127,12 +127,12 @@ _FEATURE_ATTRS = {
         mandatory = False,
     ),
     "hardcode_sysroot_ld_linux": attr.bool(
-        default = True,
+        default = False,
         doc = "Whether the sysroot ld-linux.so should be hardcoded into the ELF binaries or not." +
             " This is useful when running tests so that the host ld-linux.so is overridden.",
     ),
     "hardcode_sysroot_rpath": attr.bool(
-        default = True,
+        default = False,
         doc = "Whether the sysroot search paths should be hardcoded into the ELF binaries or not." +
             " This is useful when running tests so that libraries are searched on the sysroot first.",
     ),


### PR DESCRIPTION
I think users want to explicitly opt-in to this. Doing it by default produces non-portable ELF binaries.