### PR TITLE
feat: static libstdc++

### DIFF
--- a/toolchain/config.bzl.tpl
+++ b/toolchain/config.bzl.tpl
@@ -105,7 +105,7 @@ def _impl(ctx):
                             "-Wl,-z,relro,-z,now",
                             "-no-canonical-prefixes",
                             "-pass-exit-codes",
-                            "-lstdc++",
+                            "-l:libstdc++.a",
                         ] + ([
                             "-Wl,-rpath,{0}/lib:{0}/usr/lib".format(builtin_sysroot),
                         ] if hardcode_sysroot_rpath else []) + ([

--- a/toolchain/config.bzl.tpl
+++ b/toolchain/config.bzl.tpl
@@ -105,6 +105,15 @@ def _impl(ctx):
                             "-Wl,-z,relro,-z,now",
                             "-no-canonical-prefixes",
                             "-pass-exit-codes",
+                            # This is particularly useful when compiling only C code that doesn't rely
+                            # on the C++ standard libraries since those symbols can be easily stripped
+                            # out of the binary.
+                            #
+                            # For C++ code, each binary will carry the necessary libstdc++ symbols,
+                            # but I see this as an advantage since it makes the code more portable.
+                            # Different than statically linking the libc, static linking of libstdc++
+                            # generally doesn't incur any penalties other than the output binary size,
+                            # which is less than 1Mb in overhead.
                             "-l:libstdc++.a",
                         ] + ([
                             "-Wl,-rpath,{0}/lib:{0}/usr/lib".format(builtin_sysroot),


### PR DESCRIPTION
This is particularly useful when compiling only C code that doesn't rely on the C++ standard libraries since those symbols can be easily stripped out of the binary.

For C++ code, each binary will carry the necessary libstdc++ symbols, but I see this as an advantage since it makes the code more portable. Different than statically linking the libc, static linking of libstdc++ generally doesn't incur any penalties other than the output binary size, which is less than 1Mb in overhead.