### PR TITLE
feat: work with RBE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
-build --action_env CC=/bin/false
+build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build --incompatible_strict_action_env=true
 build --incompatible_enable_cc_toolchain_resolution
 
 test --sandbox_default_allow_network=false

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,6 +52,8 @@ load("//sysroot:flags.bzl", "cflags", "cxxflags", "ldflags", "includes")
 
 GCC_VERSION = "10.3.0"
 
+extra_cflags = ["-Wno-implicit-function-declaration"]
+
 extra_ld_flags = [
     "-l:libstdc++.a",
     "-lm",
@@ -60,7 +62,7 @@ extra_ld_flags = [
 gcc_register_toolchain(
     name = "gcc_toolchain_x86_64",
     bazel_gcc_toolchain_workspace_name = "",
-    extra_cflags = cflags,
+    extra_cflags = cflags + extra_cflags,
     extra_cxxflags = cxxflags,
     extra_includes = includes("x86_64", GCC_VERSION),
     extra_ldflags = ldflags("x86_64", GCC_VERSION) + extra_ld_flags,
@@ -74,7 +76,7 @@ gcc_register_toolchain(
 gcc_register_toolchain(
     name = "gcc_toolchain_aarch64",
     bazel_gcc_toolchain_workspace_name = "",
-    extra_cflags = cflags,
+    extra_cflags = cflags + extra_cflags,
     extra_cxxflags = cxxflags,
     extra_includes = includes("aarch64", GCC_VERSION),
     extra_ldflags = ldflags("aarch64", GCC_VERSION) + extra_ld_flags,
@@ -89,7 +91,7 @@ gcc_register_toolchain(
     name = "gcc_toolchain_armv7",
     bazel_gcc_toolchain_workspace_name = "",
     binary_prefix = "arm",
-    extra_cflags = cflags,
+    extra_cflags = cflags + extra_cflags,
     extra_cxxflags = cxxflags,
     extra_includes = includes("armv7", GCC_VERSION),
     extra_ldflags = ldflags("armv7", GCC_VERSION) + extra_ld_flags,

--- a/internal.bzl
+++ b/internal.bzl
@@ -50,15 +50,6 @@ def internal_dependencies():
 
     maybe(
         http_archive,
-        name = "zlib",
-        build_file = "@//:third-party/zlib.BUILD",
-        sha256 = "7db46b8d7726232a621befaab4a1c870f00a90805511c0e0090441dac57def18",
-        strip_prefix = "zlib-1.2.12",
-        url = "https://zlib.net/zlib-1.2.12.tar.xz",
-    )
-
-    maybe(
-        http_archive,
         name = "com_google_protobuf",
         sha256 = "3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568",
         strip_prefix = "protobuf-3.19.4",

--- a/sysroot/flags.bzl
+++ b/sysroot/flags.bzl
@@ -8,12 +8,14 @@ ARCH_AARCH64 = "aarch64"
 cflags = [
     "-fdiagnostics-color=always",
     "-nostdinc",
+    "-B{toolchain_root}/bin",
 ]
 
 cxxflags = [
     "-fdiagnostics-color=always",
     "-nostdinc",
     "-nostdinc++",
+    "-B{toolchain_root}/bin",
 ]
 
 # buildifier: disable=function-docstring
@@ -33,6 +35,7 @@ def ldflags(arch, gcc_version):
     else:
         fail("unknown arch")
     return [
+        "-B{toolchain_root}/bin",
         "-B{sysroot}" + "/usr/{lib}".format(lib = lib),
         "-B{sysroot}" + "/{arch_specific_prefix}{lib}".format(
             arch_specific_prefix = arch_specific_prefix,

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -119,7 +119,7 @@ def _get_tool_paths(rctx, execroot, binary_prefix):
 
     tool_paths = {}
     for name, real_path in real_tool_paths.items():
-        wrapped_tool_path = "bin/wrapped-{}".format(name)
+        wrapped_tool_path = paths.join("bin", name)
         rctx.template(
             wrapped_tool_path,
             rctx.attr._wrapper_sh_template,

--- a/toolchain/toolchain.BUILD.bazel.tpl
+++ b/toolchain/toolchain.BUILD.bazel.tpl
@@ -61,6 +61,7 @@ exports_files(glob(["bin/**"]))
 filegroup(
     name = "compiler_files",
     srcs = [
+        ":as",
         ":gcc",
         ":include",
     ] + ([sysroot_label] if sysroot_label else []),
@@ -69,9 +70,10 @@ filegroup(
 filegroup(
     name = "linker_files",
     srcs = [
+        ":ar",
         ":gcc",
+        ":ld",
         ":lib",
-        ":linker_files_binutils",
     ] + ([sysroot_label] if sysroot_label else []),
 )
 
@@ -107,8 +109,8 @@ filegroup(
         "bin/__binary_prefix__-linux-cpp.br_real",
         "bin/__binary_prefix__-linux-gcc",
         "bin/__binary_prefix__-linux-gcc.br_real",
-        "bin/wrapped-cpp",
-        "bin/wrapped-gcc",
+        "bin/cpp",
+        "bin/gcc",
     ] + glob([
         "**/cc1plus",
         "**/cc1",
@@ -141,14 +143,6 @@ filegroup(
 )
 
 filegroup(
-    name = "linker_files_binutils",
-    srcs = [
-        ":ar",
-        ":ld",
-    ],
-)
-
-filegroup(
     name = "objcopy_files",
     srcs = [":objcopy"],
 )
@@ -163,7 +157,7 @@ filegroup(
     srcs = [
         "bin/__binary_prefix__-linux-ld",
         "bin/__binary_prefix__-linux-ld.bfd",
-        "bin/wrapped-ld",
+        "bin/ld",
     ],
 )
 
@@ -171,7 +165,7 @@ filegroup(
     name = "ar",
     srcs = [
         "bin/__binary_prefix__-linux-ar",
-        "bin/wrapped-ar",
+        "bin/ar",
     ] + glob(["bin/__binary_prefix__-buildroot-*-ar"]),
 )
 
@@ -179,7 +173,7 @@ filegroup(
     name = "as",
     srcs = [
         "bin/__binary_prefix__-linux-as",
-        "bin/wrapped-as",
+        "bin/as",
     ],
 )
 
@@ -187,7 +181,7 @@ filegroup(
     name = "nm",
     srcs = [
         "bin/__binary_prefix__-linux-nm",
-        "bin/wrapped-nm",
+        "bin/nm",
     ],
 )
 
@@ -195,7 +189,7 @@ filegroup(
     name = "objcopy",
     srcs = [
         "bin/__binary_prefix__-linux-objcopy",
-        "bin/wrapped-objcopy",
+        "bin/objcopy",
     ],
 )
 
@@ -203,7 +197,7 @@ filegroup(
     name = "objdump",
     srcs = [
         "bin/__binary_prefix__-linux-objdump",
-        "bin/wrapped-objdump",
+        "bin/objdump",
     ],
 )
 
@@ -221,6 +215,6 @@ filegroup(
     name = "strip",
     srcs = [
         "bin/__binary_prefix__-linux-strip",
-        "bin/wrapped-strip",
+        "bin/strip",
     ],
 )


### PR DESCRIPTION
This is a pre-requisite to allow this repository to work with Remote Build Execution.
With RBE, the environment is much more strict, so in this commit, I fix the missing GNU assembler as a dependency to the compilation files (previously working as a side-effect of it being in the local disk) and set the `-B` flags to the compiler so that it finds binutils in the right location.