### PR TITLE
fix: missing gcc runtime shared object deps

### DIFF
--- a/toolchain/toolchain.BUILD.bazel.tpl
+++ b/toolchain/toolchain.BUILD.bazel.tpl
@@ -114,6 +114,9 @@ filegroup(
     ] + glob([
         "**/cc1plus",
         "**/cc1",
+        "lib/libgmp.so*",
+        "lib/libmpc.so*",
+        "lib/libmpfr.so*",
     ]),
 )
 


### PR DESCRIPTION
This was raised when using this toolchain for RBE on images that don't have those libraries installed in the system.
I just realized they are in the bootlin toolchain, so we can just use them. It fixes https://github.com/aspect-build/gcc-toolchain/issues/27.