### PR TITLE
rm: rules_perl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,11 +107,6 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 
 rules_foreign_cc_dependencies()
 
-load("@rules_perl//perl:deps.bzl", "perl_register_toolchains", "perl_rules_dependencies")
-
-perl_rules_dependencies()
-perl_register_toolchains()
-
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()

--- a/examples/openssl/BUILD.bazel
+++ b/examples/openssl/BUILD.bazel
@@ -16,9 +16,6 @@ configure_make(
         "no-weak-ssl-ciphers",
         "no-shared",
     ],
-    env = {
-        "PERL": "$$EXT_BUILD_ROOT$$/$(PERL)",
-    },
     lib_name = "openssl",
     lib_source = "@openssl//:srcs",
     out_static_libs = [
@@ -29,7 +26,6 @@ configure_make(
         "install_sw",
         "install_ssldirs",
     ],
-    toolchains = ["@rules_perl//:current_toolchain"],
     visibility = ["//visibility:public"],
 )
 

--- a/internal.bzl
+++ b/internal.bzl
@@ -25,14 +25,6 @@ def internal_dependencies():
 
     maybe(
         http_archive,
-        name = "rules_perl",
-        sha256 = "5696d108f749e300560362a3b7201f1f57b6ae451b0a0176e5f0a979ebf8e192",
-        strip_prefix = "rules_perl-3f52cee1916f6fc1c499da4a89d7f065a287ae29",
-        url = "https://github.com/bazelbuild/rules_perl/archive/3f52cee1916f6fc1c499da4a89d7f065a287ae29.tar.gz",
-    )
-
-    maybe(
-        http_archive,
         name = "rules_foreign_cc",
         sha256 = "6041f1374ff32ba711564374ad8e007aef77f71561a7ce784123b9b4b88614fc",
         strip_prefix = "rules_foreign_cc-0.8.0",


### PR DESCRIPTION
This is making RBE confused when the host is macOS. rules_perl is not really doing anything useful for a hermetic toolchain anyways.