### PR TITLE
fix: use a well-maintained image for rbe

### DIFF
--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -33,7 +33,7 @@ platform(
     ],
     exec_properties = {
         "OSFamily": "Linux",
-        "container-image": "docker://quay.io/libpod/ubuntu_podman",
+        "container-image": "docker://registry-1.docker.io/library/python:3.10.4@sha256:3b8fdb75de9a3189c49279ebcdddaedba0a4f7a4a19765d38e8b819589b0927a",
     },
     visibility = ["//visibility:public"],
 )

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -33,7 +33,7 @@ platform(
     ],
     exec_properties = {
         "OSFamily": "Linux",
-        "container-image": "docker://registry-1.docker.io/library/python:3.10.4@sha256:3b8fdb75de9a3189c49279ebcdddaedba0a4f7a4a19765d38e8b819589b0927a",
+        "container-image": "docker://public.ecr.aws/docker/library/python@sha256:247105bbbe7f7afc7c12ac893be65b5a32951c1d0276392dc2bf09861ba288a6",
     },
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
We not only switch to the official Python image but also pin it to a specific version (including its sha256).