### PR TITLE
fix: user_compile_flags for all compile actions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,8 +52,6 @@ load("//sysroot:flags.bzl", "cflags", "cxxflags", "ldflags", "includes")
 
 GCC_VERSION = "10.3.0"
 
-extra_cflags = ["-Wno-implicit-function-declaration"]
-
 extra_ld_flags = [
     "-l:libstdc++.a",
     "-lm",
@@ -62,7 +60,7 @@ extra_ld_flags = [
 gcc_register_toolchain(
     name = "gcc_toolchain_x86_64",
     bazel_gcc_toolchain_workspace_name = "",
-    extra_cflags = cflags + extra_cflags,
+    extra_cflags = cflags,
     extra_cxxflags = cxxflags,
     extra_ldflags = ldflags("x86_64", GCC_VERSION) + extra_ld_flags,
     includes = includes("x86_64", GCC_VERSION),
@@ -76,7 +74,7 @@ gcc_register_toolchain(
 gcc_register_toolchain(
     name = "gcc_toolchain_aarch64",
     bazel_gcc_toolchain_workspace_name = "",
-    extra_cflags = cflags + extra_cflags,
+    extra_cflags = cflags,
     extra_cxxflags = cxxflags,
     extra_ldflags = ldflags("aarch64", GCC_VERSION) + extra_ld_flags,
     includes = includes("aarch64", GCC_VERSION),
@@ -91,7 +89,7 @@ gcc_register_toolchain(
     name = "gcc_toolchain_armv7",
     bazel_gcc_toolchain_workspace_name = "",
     binary_prefix = "arm",
-    extra_cflags = cflags + extra_cflags,
+    extra_cflags = cflags,
     extra_cxxflags = cxxflags,
     extra_ldflags = ldflags("armv7", GCC_VERSION) + extra_ld_flags,
     includes = includes("armv7", GCC_VERSION),

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -265,7 +265,7 @@ def _impl(ctx):
         enabled = True,
         flag_sets = [
             flag_set(
-                actions = all_cpp_compile_actions,
+                actions = all_compile_actions,
                 flag_groups = [
                     flag_group(
                         flags = ["%{user_compile_flags}"],


### PR DESCRIPTION
The `user_compile_flags_feature` was missing other compile actions, e.g., compiling C. This raised issues like missing extra `copts` from `cc_library` compiling `.c` code, leading to missing `-Wno-implicit-function-declaration` for the embedded `@zlib//:zlib`, which was producing spam warnings.