### PR TITLE
rename: pure_c -> no_libstdcxx

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,9 @@ For examples on how to use this repository, see the [examples](../examples).
 ## Pure C
 
 For targets that contain C-only code, they don't require linking against `libstdc++`. This can be
-done by adding `features = ["pure_c"]` to `cc_library` or `cc_binary`. By default, `libstdc++.so`
-will be linked to all `cc_library` and `cc_binary` targets as it's expected by the Bazel ecosystem.
+done by adding `features = ["no_libstdcxx"]` to `cc_library` or `cc_binary`. By default,
+`libstdc++.so` will be linked to all `cc_library` and `cc_binary` targets as it's expected by the
+Bazel ecosystem.
 
 ## Static libstdc++
 

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -21,7 +21,7 @@ gcc_toolchain(<a href="#gcc_toolchain-name">name</a>, <a href="#gcc_toolchain-ba
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="gcc_toolchain-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="gcc_toolchain-bazel_gcc_toolchain_workspace_name"></a>bazel_gcc_toolchain_workspace_name |  The name give to the repository when imported bazel_gcc_toolchain.   | String | optional | "bazel_gcc_toolchain" |
+| <a id="gcc_toolchain-bazel_gcc_toolchain_workspace_name"></a>bazel_gcc_toolchain_workspace_name |  The name given to the repository when imported bazel_gcc_toolchain.   | String | optional | "bazel_gcc_toolchain" |
 | <a id="gcc_toolchain-binary_prefix"></a>binary_prefix |  An explicit prefix used by each binary in bin/. Defaults to <code>&lt;target_arch&gt;</code>.   | String | optional | "" |
 | <a id="gcc_toolchain-extra_cflags"></a>extra_cflags |  Extra flags for compiling C.   | List of strings | optional | [] |
 | <a id="gcc_toolchain-extra_cxxflags"></a>extra_cxxflags |  Extra flags for compiling C++.   | List of strings | optional | [] |

--- a/examples/hello_world_c/BUILD.bazel
+++ b/examples/hello_world_c/BUILD.bazel
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 cc_binary(
     name = "hello_world_c",
     srcs = ["main.c"],
-    features = ["pure_c"],
+    features = ["no_libstdcxx"],
 )
 
 platform_transition_filegroup(

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -83,7 +83,7 @@ def _impl(ctx):
         tools = [tool(path = objcopy_tool)],
     )
 
-    pure_c_feature = feature(name = "pure_c")
+    no_libstdcxx_feature = feature(name = "no_libstdcxx")
     static_libstdcxx_feature = feature(name = "static_libstdcxx")
 
     default_link_flags_feature = feature(
@@ -112,7 +112,7 @@ def _impl(ctx):
                 with_features = [
                     with_feature_set(
                         not_features = [
-                            "pure_c",
+                            "no_libstdcxx",
                             "static_libstdcxx",
                         ],
                     ),
@@ -127,7 +127,7 @@ def _impl(ctx):
                 ],
                 with_features = [
                     with_feature_set(
-                        not_features = ["pure_c"],
+                        not_features = ["no_libstdcxx"],
                         features = ["static_libstdcxx"],
                     ),
                 ],
@@ -388,7 +388,7 @@ def _impl(ctx):
         default_compile_flags_feature,
         include_paths_feature,
         library_search_directories_feature,
-        pure_c_feature,
+        no_libstdcxx_feature,
         static_libstdcxx_feature,
         default_link_flags_feature,
         supports_dynamic_linker_feature,

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -146,7 +146,7 @@ _DOWNLOAD_TOOLCHAIN_ATTRS = {
 
 _FEATURE_ATTRS = {
     "bazel_gcc_toolchain_workspace_name": attr.string(
-        doc = "The name give to the repository when imported bazel_gcc_toolchain.",
+        doc = "The name given to the repository when imported bazel_gcc_toolchain.",
         default = "bazel_gcc_toolchain",
     ),
     "binary_prefix": attr.string(


### PR DESCRIPTION
This translates better the intention of the feature as there are other cases we may want to tweak this feature even when compiling C++. E.g. when linking against another libstdc++.so the user may want.