### PR TITLE
fix: --enable-default-pie for gcc libs in sysroot

### DIFF
--- a/sysroot/Dockerfile
+++ b/sysroot/Dockerfile
@@ -99,8 +99,9 @@ WORKDIR /build/gcc/build
 COPY --from=kernel /var/buildlibs/kernel /var/builds/sysroot
 COPY --from=glibc /var/buildlibs/glibc /var/builds/sysroot
 RUN --mount=source=configure.sh,target=/usr/bin/configure.sh IS_GCC_BUILD=1 configure.sh \
-        --disable-multilib \
+        --enable-default-pie \
         --enable-languages=c,c++,fortran \
+        --disable-multilib \
         --prefix=/var/buildlibs/gcc \
         --enable-libstdcxx-threads \
         --with-build-sysroot=/var/builds/sysroot \


### PR DESCRIPTION
This enables `-static-libgfortran` once we support Fortran.