### PR TITLE
feat: add current_static_fortran_toolchain

### DIFF
--- a/toolchain/fortran/BUILD.bazel
+++ b/toolchain/fortran/BUILD.bazel
@@ -24,3 +24,9 @@ current_fortran_toolchain(
     name = "current_fortran_toolchain",
     visibility = ["//visibility:public"],
 )
+
+current_fortran_toolchain(
+    name = "current_static_fortran_toolchain",
+    visibility = ["//visibility:public"],
+    features = ["static_libgfortran"],
+)


### PR DESCRIPTION
With this, we can get statically linked Fortran binaries using rules_foreign_cc.