### PR TITLE
fix: rules_fortran

### DIFF
--- a/rules_fortran/defs.bzl
+++ b/rules_fortran/defs.bzl
@@ -313,7 +313,7 @@ def _archive(
 def _current_fortran_toolchain_impl(ctx):
     (fortran_toolchain, feature_configuration) = _get_configuration(ctx)
     (compiler, compile_flags) = _get_compiler(fortran_toolchain, feature_configuration)
-    (_, link_flags) = _get_compiler(fortran_toolchain, feature_configuration)
+    (_, link_flags) = _get_linker(fortran_toolchain, feature_configuration)
     vars = {
         "FC": compiler,
         "FFLAGS": " ".join(compile_flags),

--- a/rules_fortran/defs.bzl
+++ b/rules_fortran/defs.bzl
@@ -236,6 +236,11 @@ def _link(
     shared_objects = []
     archives = []
     for dep in deps:
+        if CcInfo in dep:
+            for linker_input in dep[CcInfo].linking_context.linker_inputs.to_list():
+                for library in linker_input.libraries:
+                    if library.static_library:
+                        archives.append(library.static_library)
         if linkstatic and hasattr(dep.output_groups, "archive"):
             archives.append(dep.output_groups.archive.to_list()[0])
         elif not linkstatic and hasattr(dep.output_groups, "dynamic_library"):


### PR DESCRIPTION
- Fixes the wrong linker flags in current_fortran_toolchain.
- Fixes the missing static archives from cc_import.