### PR TITLE
feat: add lapack example

### DIFF
--- a/examples/lapack/BUILD.bazel
+++ b/examples/lapack/BUILD.bazel
@@ -1,0 +1,83 @@
+# Copyright (c) Joby Aviation 2022
+# Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
+
+libs = [
+    "liblapack.a",
+    "librefblas.a",
+    "libtmglib.a",
+]
+
+make(
+    name = "lapack",
+    args = [
+        "FC=\"${FC}\"",
+        "FFLAGS=\"${FFLAGS} -frecursive\"",
+        "LD=\"${LD}\"",
+        "LDFLAGS=\"${FLDFLAGS}\"",
+        "BLASLIB='$(TOPSRCDIR)/librefblas.a'",
+        "CBLASLIB='$(TOPSRCDIR)/libcblas.a'",
+        "LAPACKLIB='$(TOPSRCDIR)/liblapack.a'",
+        "TMGLIB='$(TOPSRCDIR)/libtmglib.a'",
+        "LAPACKELIB='$(TOPSRCDIR)/liblapacke.a'",
+        "TIMER='INT_ETIME'",
+    ],
+    env = {
+        "FC": "$$EXT_BUILD_ROOT$$/$(FC)",
+        "FFLAGS": "$(FFLAGS)",
+        "LD": "$$EXT_BUILD_ROOT$$/$(LD)",
+        "FLDFLAGS": "$(FLDFLAGS)",
+    },
+    lib_name = "lapack",
+    lib_source = "@lapack//:srcs",
+    out_static_libs = libs,
+    postfix_script = "\n".join([
+        "cp {0} $$INSTALLDIR$$/lib/{0}".format(lib)
+        for lib in libs
+    ]),
+    targets = ["all"],
+    toolchains = [
+        "@bazel_tools//tools/cpp:current_cc_toolchain",
+        "//toolchain/fortran:current_static_fortran_toolchain",
+    ],
+)
+
+filegroup(
+    name = "lapack_gen_dir",
+    srcs = [":lapack"],
+    output_group = "gen_dir",
+)
+
+genrule(
+    name = "libs_reexport",
+    srcs = [":lapack_gen_dir"],
+    outs = libs,
+    cmd = "set -o errexit -o nounset -o pipefail\n" + "\n".join([
+        "cp '$(execpath :lapack_gen_dir)/lib/{0}' '$(execpath :{0})'".format(lib)
+        for lib in libs
+    ]),
+)
+
+[
+    cc_import(
+        name = lib.replace(".a", ""),
+        static_library = ":{}".format(lib),
+        visibility = ["//visibility:public"],
+    )
+    for lib in libs
+]
+
+# TODO(f0rmiga): cross-compile to aarch64 and armv7.

--- a/examples/lapack/BUILD.bazel
+++ b/examples/lapack/BUILD.bazel
@@ -24,10 +24,6 @@ libs = [
 make(
     name = "lapack",
     args = [
-        "FC=\"${FC}\"",
-        "FFLAGS=\"${FFLAGS} -frecursive\"",
-        "LD=\"${LD}\"",
-        "LDFLAGS=\"${FLDFLAGS}\"",
         "BLASLIB='$(TOPSRCDIR)/librefblas.a'",
         "CBLASLIB='$(TOPSRCDIR)/libcblas.a'",
         "LAPACKLIB='$(TOPSRCDIR)/liblapack.a'",
@@ -37,9 +33,9 @@ make(
     ],
     env = {
         "FC": "$$EXT_BUILD_ROOT$$/$(FC)",
-        "FFLAGS": "$(FFLAGS)",
+        "FFLAGS": "$(FFLAGS) -frecursive",
         "LD": "$$EXT_BUILD_ROOT$$/$(LD)",
-        "FLDFLAGS": "$(FLDFLAGS)",
+        "LDFLAGS": "$(FLDFLAGS)",
     },
     lib_name = "lapack",
     lib_source = "@lapack//:srcs",

--- a/examples/lapack/BUILD.bazel
+++ b/examples/lapack/BUILD.bazel
@@ -48,7 +48,16 @@ make(
         "cp {0} $$INSTALLDIR$$/lib/{0}".format(lib)
         for lib in libs
     ]),
-    targets = ["all"],
+    targets = [
+        "lapack_install",
+        "blaslib",
+        "lapacklib",
+        "tmglib",
+
+        # Uncomment the following if testing the built artifacts is required:
+        # "blas_testing",
+        # "lapack_testing",
+    ],
     toolchains = [
         "@bazel_tools//tools/cpp:current_cc_toolchain",
         "//toolchain/fortran:current_static_fortran_toolchain",

--- a/internal.bzl
+++ b/internal.bzl
@@ -57,6 +57,47 @@ def internal_dependencies():
 
     maybe(
         http_archive,
+        name = "lapack",
+        build_file_content = _ALL_SRCS,
+        patch_cmds = ["""\
+cat > make.inc <<EOF
+####################################################################
+#  LAPACK make include file.                                       #
+####################################################################
+
+SHELL = $0
+
+CC ?=
+
+FC ?=
+FFLAGS ?=
+FFLAGS_DRV ?=
+FFLAGS_NOOPT ?=
+
+LDFLAGS ?=
+
+AR ?=
+ARFLAGS = cr
+RANLIB = echo
+
+BLASLIB ?=
+CBLASLIB ?=
+LAPACKLIB ?=
+TMGLIB ?=
+LAPACKELIB ?=
+
+DOCSDIR ?=
+
+TIMER ?=
+EOF
+"""],
+        sha256 = "cd005cd021f144d7d5f7f33c943942db9f03a28d110d6a3b80d718a295f7f714",
+        strip_prefix = "lapack-3.10.1",
+        url = "https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.10.1.tar.gz",
+    )
+
+    maybe(
+        http_archive,
         name = "com_google_protobuf",
         sha256 = "3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568",
         strip_prefix = "protobuf-3.19.4",


### PR DESCRIPTION
This example uses rules_foreign_cc to build LAPACK, which is a Fortran library.