### PR TITLE
fix: avoid file names collisions

### DIFF
--- a/rules_fortran/defs.bzl
+++ b/rules_fortran/defs.bzl
@@ -173,7 +173,7 @@ def _compile(
 ):
     (compiler, compile_flags) = _get_compiler(fortran_toolchain, feature_configuration, fopts)
     objects = [
-        actions.declare_file(paths.replace_extension(paths.basename(src.path), ".o"))
+        actions.declare_file(paths.replace_extension(src.path, ".o"))
         for src in srcs
     ]
     defines_flags = ["-D{}".format(define) for define in defines]


### PR DESCRIPTION
If 2 files have the same name under a coarse-grained Bazel package building multiple sub-directories, this can cause collisions. With this fix, the file paths are preserved and only the extension is replaced.