### PR TITLE
fix: target_compatible_with other workspaces

### DIFF
--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -49,7 +49,7 @@ def _gcc_toolchain_impl(rctx):
     ]
 
     target_compatible_with = [
-        str(Label(v.format(target_arch = target_arch)))
+        v.format(target_arch = target_arch)
         for v in rctx.attr.target_compatible_with
     ]
 


### PR DESCRIPTION
When passing different workspaces to customize the target compatibility, Label removes the workspace name, rendering the wrong string back into the BUILD.bazel files.