### PR TITLE
fix: sanitizers with Fortran

### DIFF
--- a/rules_fortran/defs.bzl
+++ b/rules_fortran/defs.bzl
@@ -153,7 +153,7 @@ def _get_configuration(ctx):
         "fortran_compile_flags",
         "fortran_link_flags",
         "no_libstdcxx",
-    ] + ctx.attr.features
+    ] + ctx.features
     fortran_toolchain = ctx.toolchains[ctx.attr._fortran_toolchain_type.label].cc
     feature_configuration = cc_common.configure_features(
         cc_toolchain = fortran_toolchain,

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -607,7 +607,7 @@ def _sanitizer_feature(sanitizer):
         name = sanitizer.name,
         flag_sets = [
             flag_set(
-                actions = all_compile_actions,
+                actions = all_compile_actions + [FORTRAN_ACTION_NAMES.fortran_compile],
                 flag_groups = [
                     flag_group(
                         flags = sanitizer.cflags,


### PR DESCRIPTION
This enables Fortran code (or dependent systems that use Fortran code) to be sanitized.