### PR TITLE
Set default visibility for toolchains to public

### DIFF
--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -529,6 +529,7 @@ filegroup(
 """
 
 _TOOLCHAIN_BUILD_FILE_CONTENT = """\
+package(default_visibility = ["//visibility:public"])
 load("@rules_cc//cc:defs.bzl", "cc_toolchain")
 load("@{gcc_toolchain_workspace_name}//toolchain:cc_toolchain_config.bzl", "cc_toolchain_config")
 load("@{gcc_toolchain_workspace_name}//toolchain/fortran:defs.bzl", "fortran_toolchain")


### PR DESCRIPTION
Use public visibility for toolchains and related filegroups. This allows e.g. defining a toolchain as an alias target for a downstream project.