### PR TITLE
chore: update renovate config and add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# See CONTRIBUTING.md for instructions.
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+# Commitizen runs in commit-msg stage
+# but we don't want to run the other hooks on commit messages
+default_stages: [commit]
+
+repos:
+  # Check formatting and lint for starlark code
+  - repo: https://github.com/keith/pre-commit-buildifier
+    rev: 4.0.1.1
+    hooks:
+      - id: buildifier
+      - id: buildifier-lint
+  # Enforce that commit messages allow for later changelog generation
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v2.18.0
+    hooks:
+      # Requires that commitizen is already installed
+      - id: commitizen
+        stages: [commit-msg]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v2.4.0"
+    hooks:
+      - id: prettier

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,16 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
   "extends": [
-    "config:base"
-  ]
+    "config:base",
+    ":preserveSemverRanges",
+    ":rebaseStalePrs",
+    "schedule:weekly",
+    "group:recommended",
+    "group:monorepos",
+    "workarounds:all"
+  ],
+
+  "labels": ["deps"],
+  "dependencyDashboard": true
 }


### PR DESCRIPTION
No need to run CI on this one. Just lining renovate configs through our OSS repos. This repo was also missing our standard pre-commit hook.