### PR TITLE
chore: add build_test targets to examples

### DIFF
--- a/examples/avl/BUILD.bazel
+++ b/examples/avl/BUILD.bazel
@@ -12,8 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 alias(
     name = "avl",
     actual = "@avl",
+)
+
+build_test(
+    name = "avl_build_test",
+    targets = [":avl"],
 )

--- a/examples/hello_world_c/BUILD.bazel
+++ b/examples/hello_world_c/BUILD.bazel
@@ -14,7 +14,17 @@
 # limitations under the License.
 
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+build_test(
+    name = "hello_world_c_build_test",
+    targets = [
+        ":hello_world_c",
+        ":hello_world_c_linux_aarch64_tar",
+        ":hello_world_c_linux_armv7_tar",
+    ],
+)
 
 cc_binary(
     name = "hello_world_c",
@@ -24,8 +34,8 @@ cc_binary(
 
 platform_transition_filegroup(
     name = "hello_world_c_linux_aarch64",
-    target_platform = "//platforms:aarch64_linux",
     srcs = [":hello_world_c"],
+    target_platform = "//platforms:aarch64_linux",
 )
 
 pkg_tar(
@@ -37,8 +47,8 @@ pkg_tar(
 
 platform_transition_filegroup(
     name = "hello_world_c_linux_armv7",
-    target_platform = "//platforms:armv7_linux",
     srcs = [":hello_world_c"],
+    target_platform = "//platforms:armv7_linux",
 )
 
 pkg_tar(

--- a/examples/hello_world_cpp/BUILD.bazel
+++ b/examples/hello_world_cpp/BUILD.bazel
@@ -14,7 +14,17 @@
 # limitations under the License.
 
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+build_test(
+    name = "hello_world_cpp_build_test",
+    targets = [
+        ":hello_world_cpp",
+        ":hello_world_cpp_linux_aarch64_tar",
+        ":hello_world_cpp_linux_armv7_tar",
+    ],
+)
 
 cc_binary(
     name = "hello_world_cpp",
@@ -24,8 +34,8 @@ cc_binary(
 
 platform_transition_filegroup(
     name = "hello_world_cpp_linux_aarch64",
-    target_platform = "//platforms:aarch64_linux",
     srcs = [":hello_world_cpp"],
+    target_platform = "//platforms:aarch64_linux",
 )
 
 pkg_tar(
@@ -37,8 +47,8 @@ pkg_tar(
 
 platform_transition_filegroup(
     name = "hello_world_cpp_linux_armv7",
-    target_platform = "//platforms:armv7_linux",
     srcs = [":hello_world_cpp"],
+    target_platform = "//platforms:armv7_linux",
 )
 
 pkg_tar(
@@ -57,8 +67,8 @@ cc_binary(
 
 platform_transition_filegroup(
     name = "hello_world_cpp_static_linux_aarch64",
-    target_platform = "//platforms:aarch64_linux",
     srcs = [":hello_world_cpp_static"],
+    target_platform = "//platforms:aarch64_linux",
 )
 
 pkg_tar(
@@ -70,8 +80,8 @@ pkg_tar(
 
 platform_transition_filegroup(
     name = "hello_world_cpp_static_linux_armv7",
-    target_platform = "//platforms:armv7_linux",
     srcs = [":hello_world_cpp_static"],
+    target_platform = "//platforms:armv7_linux",
 )
 
 pkg_tar(

--- a/examples/hello_world_fortran/BUILD.bazel
+++ b/examples/hello_world_fortran/BUILD.bazel
@@ -14,8 +14,18 @@
 # limitations under the License.
 
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//rules_fortran:defs.bzl", "fortran_binary")
+
+build_test(
+    name = "hello_world_fortran_build_test",
+    targets = [
+        ":hello_world_fortran",
+        ":hello_world_fortran_aarch64_tar",
+        ":hello_world_fortran_armv7_tar",
+    ],
+)
 
 fortran_binary(
     name = "hello_world_fortran",
@@ -24,8 +34,8 @@ fortran_binary(
 
 platform_transition_filegroup(
     name = "hello_world_fortran_aarch64",
-    target_platform = "//platforms:aarch64_linux",
     srcs = [":hello_world_fortran"],
+    target_platform = "//platforms:aarch64_linux",
 )
 
 pkg_tar(
@@ -37,8 +47,8 @@ pkg_tar(
 
 platform_transition_filegroup(
     name = "hello_world_fortran_armv7",
-    target_platform = "//platforms:armv7_linux",
     srcs = [":hello_world_fortran"],
+    target_platform = "//platforms:armv7_linux",
 )
 
 pkg_tar(

--- a/examples/openssl/BUILD.bazel
+++ b/examples/openssl/BUILD.bazel
@@ -14,8 +14,18 @@
 # limitations under the License.
 
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+build_test(
+    name = "openssl_build_test",
+    targets = [
+        ":openssl",
+        ":openssl_linux_aarch64_tar",
+        ":openssl_linux_armv7_tar",
+    ],
+)
 
 configure_make(
     name = "openssl",
@@ -46,8 +56,8 @@ configure_make(
 
 platform_transition_filegroup(
     name = "openssl_linux_aarch64",
-    target_platform = "//platforms:aarch64_linux",
     srcs = [":openssl"],
+    target_platform = "//platforms:aarch64_linux",
 )
 
 pkg_tar(
@@ -59,8 +69,8 @@ pkg_tar(
 
 platform_transition_filegroup(
     name = "openssl_linux_armv7",
-    target_platform = "//platforms:armv7_linux",
     srcs = [":openssl"],
+    target_platform = "//platforms:armv7_linux",
 )
 
 pkg_tar(

--- a/examples/protobuf/BUILD.bazel
+++ b/examples/protobuf/BUILD.bazel
@@ -14,9 +14,19 @@
 # limitations under the License.
 
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+
+build_test(
+    name = "hello_world_cc_proto_build_test",
+    targets = [
+        ":hello_world_cc_proto",
+        ":hello_world_cc_proto_linux_aarch64_tar",
+        ":hello_world_cc_proto_linux_armv7_tar",
+    ],
+)
 
 proto_library(
     name = "hello_world_proto",
@@ -30,8 +40,8 @@ cc_proto_library(
 
 platform_transition_filegroup(
     name = "hello_world_cc_proto_linux_aarch64",
-    target_platform = "//platforms:aarch64_linux",
     srcs = [":hello_world_cc_proto"],
+    target_platform = "//platforms:aarch64_linux",
 )
 
 pkg_tar(
@@ -43,8 +53,8 @@ pkg_tar(
 
 platform_transition_filegroup(
     name = "hello_world_cc_proto_linux_armv7",
-    target_platform = "//platforms:armv7_linux",
     srcs = [":hello_world_cc_proto"],
+    target_platform = "//platforms:armv7_linux",
 )
 
 pkg_tar(

--- a/examples/tabulate_fortran/BUILD.bazel
+++ b/examples/tabulate_fortran/BUILD.bazel
@@ -14,8 +14,18 @@
 # limitations under the License.
 
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//rules_fortran:defs.bzl", "fortran_binary")
+
+build_test(
+    name = "tabulate_fortran_build_test",
+    targets = [
+        ":tabulate_fortran",
+        ":tabulate_fortran_aarch64_tar",
+        ":tabulate_fortran_armv7_tar",
+    ],
+)
 
 fortran_binary(
     name = "tabulate_fortran",
@@ -27,8 +37,8 @@ fortran_binary(
 
 platform_transition_filegroup(
     name = "tabulate_fortran_aarch64",
-    target_platform = "//platforms:aarch64_linux",
     srcs = [":tabulate_fortran"],
+    target_platform = "//platforms:aarch64_linux",
 )
 
 pkg_tar(
@@ -40,8 +50,8 @@ pkg_tar(
 
 platform_transition_filegroup(
     name = "tabulate_fortran_armv7",
-    target_platform = "//platforms:armv7_linux",
     srcs = [":tabulate_fortran"],
+    target_platform = "//platforms:armv7_linux",
 )
 
 pkg_tar(


### PR DESCRIPTION
Sanity check that examples build incase `--build_tests_only` ever gets set by accident.