### PR TITLE
fix: fortran object compilation path should include directories

### DIFF
--- a/rules_fortran/defs.bzl
+++ b/rules_fortran/defs.bzl
@@ -293,7 +293,7 @@ def _compile(
         struct(
             source_file = source_file,
             output_file = actions.declare_file(
-                paths.replace_extension(source_file.basename, ".o"),
+                paths.replace_extension(source_file.path, ".o"),
             ),
             module_files = [
                 actions.declare_file(module_file)
@@ -306,7 +306,7 @@ def _compile(
     ] + [
         struct(
             source_file = source_file,
-            output_file = actions.declare_file(paths.replace_extension(source_file.basename, ".o")),
+            output_file = actions.declare_file(paths.replace_extension(source_file.path, ".o")),
             module_files = [],
         )
         for source_file in srcs_files


### PR DESCRIPTION
By using the entire path, we deconflict files with the same name under different directories in the same Bazel package.