### PR TITLE
fix: use repository-relative label for bzlmod compatibility

### DIFF
--- a/internal.bzl
+++ b/internal.bzl
@@ -42,7 +42,7 @@ def _lapack():
 def _avl():
     http_archive(
         name = "avl",
-        build_file = "@//:examples/avl/avl.BUILD.bazel",
+        build_file = "//:examples/avl/avl.BUILD.bazel",
         sha256 = "6d62e563578b79795a84958cfe4e221a4c9847fbeb4a821d45bc049934fc6a90",
         strip_prefix = "Avl",
         url = "https://web.mit.edu/drela/Public/web/avl/avl3.40b.tgz",


### PR DESCRIPTION
When gcc-toolchain is used as a bzlmod dependency, the label `@//:examples/avl/avl.BUILD.bazel` attempts to reference the _main_ repository `@`, which is not visible from the extension context.

This change updates the label to `//:examples/avl/avl.BUILD.bazel`, which refers to the _current_ repository (`@@gcc_toolchain+` when used as a dependency), fixing the error:
```sh
$ bazel mod deps
ERROR: [redacted]/external/gcc_toolchain+/internal.bzl:43:17: Traceback (most recent call last):
    File "[redacted]/external/gcc_toolchain+/internal.bzl", line 117, column 9, in _non_bazel_dependencies_ext_impl
        _avl()
    File "[redacted]/external/gcc_toolchain+/internal.bzl", line 43, column 17, in _avl
        http_archive(
Error in repository_rule: no repository visible as '@' in the extension '@@gcc_toolchain+//:internal.bzl%non_bazel_dependencies', but referenced by label '@//:examples/avl/avl.BUILD.bazel' in attribute 'build_file' of http_archive 'avl'.
ERROR: error evaluating module extension @@gcc_toolchain+//:internal.bzl%non_bazel_dependencies
```