### PR TITLE
fix: sanitizer filegroups silently empty on aarch64 toolchain

### DIFF
--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -841,7 +841,7 @@ cc_library(
 filegroup(
     name = "libasan",
     srcs = glob([
-        "lib*/libasan.so",
+        "**/lib*/libasan.so",
     ], allow_empty=True),
     visibility = ["//visibility:public"],
 )
@@ -849,7 +849,7 @@ filegroup(
 filegroup(
     name = "liblsan",
     srcs = glob([
-        "lib*/liblsan.so",
+        "**/lib*/liblsan.so",
     ], allow_empty=True),
     visibility = ["//visibility:public"],
 )
@@ -857,8 +857,7 @@ filegroup(
 filegroup(
     name = "libtsan",
     srcs = glob([
-        "lib*/libtsan.so",
-        "lib*/lib64/libtsan.so",
+        "**/lib*/libtsan.so",
     ], allow_empty=True),
     visibility = ["//visibility:public"],
 )
@@ -866,7 +865,7 @@ filegroup(
 filegroup(
     name = "libubsan",
     srcs = glob([
-        "lib*/libubsan.so",
+        "**/lib*/libubsan.so",
     ], allow_empty=True),
     visibility = ["//visibility:public"],
 )

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -868,7 +868,7 @@ cc_library(
 filegroup(
     name = "libasan",
     srcs = glob([
-        "lib*/libasan.so",
+        "**/lib*/libasan.so",
     ], allow_empty=True),
     visibility = ["//visibility:public"],
 )
@@ -876,7 +876,7 @@ filegroup(
 filegroup(
     name = "liblsan",
     srcs = glob([
-        "lib*/liblsan.so",
+        "**/lib*/liblsan.so",
     ], allow_empty=True),
     visibility = ["//visibility:public"],
 )
@@ -884,8 +884,7 @@ filegroup(
 filegroup(
     name = "libtsan",
     srcs = glob([
-        "lib*/libtsan.so",
-        "lib*/lib64/libtsan.so",
+        "**/lib*/libtsan.so",
     ], allow_empty=True),
     visibility = ["//visibility:public"],
 )
@@ -893,7 +892,7 @@ filegroup(
 filegroup(
     name = "libubsan",
     srcs = glob([
-        "lib*/libubsan.so",
+        "**/lib*/libubsan.so",
     ], allow_empty=True),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## Problem                                                                                                                       
                                                                                                                                   
  The `:libasan`, `:liblsan`, `:libtsan`, and `:libubsan` filegroups in the                                                        
  generated toolchain `BUILD` use:                                                                                                 
                                                                                                                                   
  ```python                                                                                                                        
  glob(["lib*/libasan.so"], allow_empty=True)                                                                                      
 ```                                                                                                                                  
  This pattern matches the x86_64 toolchain layout, where sanitizer                                                                
  libraries sit at <repo>/lib64/libasan.so. The aarch64 toolchain                                                                  
  places them one directory deeper:                                                                                                
                                                                                                                                   
  aarch64-linux/lib64/libasan.so                                                                                                   
                                                                                                                                   
  The single-segment lib* prefix can't match aarch64-linux/, so the                                                                
  glob produces an empty list. With allow_empty=True there is no build                                                             
  error. The failure only appears at runtime.                                                                                
                                                                                                                                   
  ## Fix                                                                                                                              

  Use a recursive glob (**/lib*/libasan.so). Matches
  libstdcxx_static cc_library a few lines above, which already uses                                                                
  glob(["**/libstdc++.a"]) for the same reason.                  

  This makes "lib*/lib64/libtsan.so" redundant and is thus removed.
  
  ## Reproduction                  
                                           
  Before:                       
`  $bazel cquery 'deps(@gcc_linux_aarch64//:libasan)' --output=files`
  (prints nothing)            

```
  $ bazel cquery 'deps(@gcc_linux_amd64//:libasan)' --output=files                                                                 
  external/.../lib64/libasan.so 
```

  After:                        
```
  $ bazel cquery 'deps(@gcc_linux_aarch64//:libasan)' --output=files
  external/.../aarch64-linux/lib64/libasan.so                    

  $ bazel cquery 'deps(@gcc_linux_amd64//:libasan)' --output=files                                                                 
  external/.../lib64/libasan.so 
```