### PR TITLE
fix: link Fortran executables with --coverage under code coverage

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Test Coverage
         run: |
           ln -s .github/workflows/.bazelrc.ci .bazelrc.ci
-          bazel coverage --config ${{ matrix.bzlmod_config }} //examples/hello_world_cpp:hello_world_cpp_test
+          bazel coverage --config ${{ matrix.bzlmod_config }} //examples/hello_world_cpp:hello_world_cpp_test //tests/coverage/...
   bazel9:
     strategy:
       matrix:

--- a/tests/coverage/BUILD.bazel
+++ b/tests/coverage/BUILD.bazel
@@ -1,0 +1,37 @@
+# Copyright (c) Thulio Ferraz Assis 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//rules_cc:defs.bzl", "cc_library")
+load("//rules_fortran:defs.bzl", "fortran_binary")
+
+cc_library(
+    name = "add_one",
+    srcs = ["add_one.c"],
+)
+
+fortran_binary(
+    name = "fortran_links_instrumented_c",
+    srcs = ["main.f90"],
+    deps = [":add_one"],
+)
+
+# Linking a coverage-instrumented C object into a Fortran executable only
+# succeeds if the fortran_coverage feature mirrors --coverage onto the
+# fortran-link-executable action. Run with --collect_code_coverage to exercise
+# that; without it this is an ordinary mixed Fortran/C link.
+build_test(
+    name = "fortran_coverage_link_test",
+    targets = [":fortran_links_instrumented_c"],
+)

--- a/tests/coverage/add_one.c
+++ b/tests/coverage/add_one.c
@@ -1,0 +1,26 @@
+// Copyright (c) Thulio Ferraz Assis 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// When Bazel collects code coverage this translation unit is compiled with
+// -fprofile-arcs -ftest-coverage, so its object file gains constructors and
+// destructors that reference __gcov_init, __gcov_exit and __gcov_merge_add.
+// Those symbols live in libgcov, which the linker only pulls in when the link
+// action receives --coverage. The branch below exists so that there is more
+// than one arc to instrument.
+int add_one(int value) {
+    if (value < 0) {
+        return value;
+    }
+    return value + 1;
+}

--- a/tests/coverage/main.f90
+++ b/tests/coverage/main.f90
@@ -1,0 +1,32 @@
+! Copyright (c) Thulio Ferraz Assis 2026
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+program fortran_links_instrumented_c
+  use, intrinsic :: iso_c_binding, only: c_int
+  implicit none
+
+  interface
+    function add_one(value) bind(C, name='add_one')
+      import :: c_int
+      integer(c_int), value :: value
+      integer(c_int) :: add_one
+    end function add_one
+  end interface
+
+  if (add_one(1_c_int) /= 2_c_int) then
+    error stop 'add_one(1) did not return 2'
+  end if
+
+  write(*,'(a)') adjustl('OK')
+end program fortran_links_instrumented_c

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -220,6 +220,36 @@ def _impl(ctx):
         ],
     )
 
+    # Bazel enables the "coverage" feature on every action whenever code coverage is being
+    # collected, but rules_cc's legacy gcc_coverage_map_format feature only attaches --coverage to
+    # the C/C++ link actions. A fortran_binary that links coverage-instrumented C/C++ objects
+    # therefore fails to link with undefined references to __gcov_init, __gcov_exit and
+    # __gcov_merge_add, so the flag has to be mirrored onto the Fortran link action.
+    #
+    # Only the link action is covered. Instrumenting fortran-compile would additionally need
+    # rules_fortran to declare the .gcno outputs and report them through InstrumentedFilesInfo;
+    # without that, -ftest-coverage would emit undeclared outputs that Bazel discards, so the
+    # Fortran sources themselves stay uninstrumented.
+    fortran_coverage_feature = feature(
+        name = "fortran_coverage",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [FORTRAN_ACTION_NAMES.fortran_link_executable],
+                flag_groups = [
+                    flag_group(
+                        flags = ["--coverage"],
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(
+                        features = ["coverage"],
+                    ),
+                ],
+            ),
+        ],
+    )
+
     if enable_fortran:
         action_configs.append(action_config(
             action_name = FORTRAN_ACTION_NAMES.fortran_compile,
@@ -545,6 +575,7 @@ def _impl(ctx):
         fortran_compile_flags_feature,
         static_libgfortran_feature,
         fortran_link_flags_feature,
+        fortran_coverage_feature,
         extra_fflags_feature,
     ) + sanitizers_features
 


### PR DESCRIPTION
A `fortran_binary` that statically links coverage-instrumented C/C++ objects fails to link under `bazel coverage`:

```
libxwin.a(Xwin2.pic.o): in function `_sub_I_00100_0':
Xwin2.c:(.text.startup._sub_I_00100_0+0x8): undefined reference to `__gcov_init'
Xwin2.c:(.text.exit._sub_D_00100_1+0x1): undefined reference to `__gcov_exit'
Xwin2.c:(.data.rel..LPBX0+0x20): undefined reference to `__gcov_merge_add'
collect2: error: ld returned 1 exit status
```

## Cause

Bazel enables the `coverage` feature on every action whenever code coverage is being collected (`configure_features`, via `ctx.configuration.coverage_enabled`). This toolchain does not set `no_legacy_features`, so rules_cc injects the legacy `coverage` / `gcc_coverage_map_format` features — and those attach `--coverage` only to the standard C/C++ link actions (`cpp_link_executable`, `cpp_link_dynamic_library`, `cpp_link_nodeps_dynamic_library`, `lto_index_for_*`).

`fortran-link-executable` is a custom action name defined by this repo, so no rules_cc feature enumerates it. `_fortran_binary_impl` builds its link line from `cc_common.get_memory_inefficient_command_line(action_name = fortran_link_executable, ...)`, which therefore contributes nothing coverage-related. The C half of the link *is* instrumented and emits `__gcov_*` references, so the link fails.

The asymmetry only shows up in the target configuration — the same binaries link fine in the exec configuration, where coverage is off, so a Fortran binary used purely as a genrule tool never trips it.

## Fix

A `fortran_coverage` feature that mirrors `--coverage` onto `fortran-link-executable`, gated with `with_feature_set(features = ["coverage"])` so non-coverage builds are byte-identical to before.

This lives in the toolchain rather than in `_fortran_binary_impl` because every other Fortran link flag here is already expressed as a feature (`fortran_link_flags`, `static_libgfortran`, `linker-lld`, the sanitizers), which keeps the flag out of the rule implementation and lets a consumer opt out per target with `features = ["-fortran_coverage"]`.

### Why link-only

Instrumenting `fortran-compile` as well would additionally require `rules_fortran` to declare the `.gcno` outputs and report them through `InstrumentedFilesInfo`. Without that, `-ftest-coverage` emits undeclared outputs that Bazel discards — cost with no usable data — so Fortran sources deliberately stay uninstrumented. Doing it properly is a larger, separate change.

## Test

`tests/coverage/` adds a `fortran_binary` linking an instrumented C `cc_library`, plus a `build_test`. It is not `manual`: without coverage it is an ordinary mixed Fortran/C link check in the regular suite, and under `--collect_code_coverage` it exercises the fix.

The existing `coverage` CI job only ran `//examples/hello_world_cpp:hello_world_cpp_test` — pure C++ — which is why this gap survived. It now also builds `//tests/coverage/...`.

## Verification

- With the fix reverted, `bazel test --collect_code_coverage //tests/coverage/...` reproduces the exact `__gcov_init` / `__gcov_exit` / `__gcov_merge_add` failure; with it, the test passes.
- The instrumented path is genuinely exercised, not trivially skipped: `libadd_one.a` carries 5 `__gcov` references, `add_one.pic.gcno` is emitted, and the linked binary runs.
- `aquery` confirms `--coverage` appears on the `FortranLink` command line under coverage and is absent without it.
- `bazel test //...` passes (12/12), as does the exact command the coverage CI job runs.
- Downstream check on a large mixed Fortran/C++/Python monorepo: 43 test targets that previously could not build under `bazel coverage` (blocked by AVL and XFOIL, both `fortran_binary` targets linking an instrumented `xwin` C library) now build and pass, and a combined LCOV report is produced.
